### PR TITLE
支持将字段设置为指针类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ func main() {
 		Prefix("prefix_").
 		// 是否添加json tag
 		EnableJsonTag(true).
+		// 字段是否使用指针类型，默认是false
+		Table2Struct(false).
 		// 生成struct的包名(默认为空的话, 则取名为: package model)
 		PackageName("model").
 		// tag字段的key值,默认是orm

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -3,8 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/gohouse/converter"
 	"log"
+
+	"github.com/gohouse/converter"
 )
 
 func main() {
@@ -19,6 +20,7 @@ func parser() {
 	packageName := flag.String("packageName", "model", "生成的struct包名")
 	tagKey := flag.String("tagKey", "orm", "字段tag的key")
 	prefix := flag.String("prefix", "", "表前缀")
+	fieldAsPtr := flag.Bool("fieldAsPtr", false, "使用指针类型")
 	version := flag.Bool("version", false, "版本号")
 	v := flag.Bool("v", false, "版本号")
 	enableJsonTag := flag.Bool("enableJsonTag", false, "是否添加json的tag,默认false")
@@ -61,6 +63,8 @@ func parser() {
 		Prefix(*prefix).
 		// 是否添加json tag
 		EnableJsonTag(*enableJsonTag).
+		// 字段是否使用指针类型
+		Table2Struct(*fieldAsPtr).
 		// 生成struct的包名(默认为空的话, 则取名为: package model)
 		PackageName(*packageName).
 		// tag字段的key值,默认是orm


### PR DESCRIPTION
因为gorm的一些限制，在做字段值更新时会遇到一些默认值问题。我们用一种比较取巧的方式，将字段置为指针，这样字段的默认值是nil，这样在更新的时候就能以一种更轻松、随意的方式进行写入。这里对代码生成工具提供一个选项来快速实现这点。